### PR TITLE
Added rollout parameter

### DIFF
--- a/lib/supply/client.rb
+++ b/lib/supply/client.rb
@@ -191,6 +191,10 @@ module Supply
     end
 
     def upload_apk_to_track(path_to_apk, track)
+      upload_apk_to_track_with_rollout(path_to_apk, track, 1.0)
+    end
+    
+    def upload_apk_to_track_with_rollout(path_to_apk, track, rollout)
       ensure_active_edit!
 
       apk = Google::APIClient::UploadIO.new(File.expand_path(path_to_apk), 'application/vnd.android.package-archive')
@@ -209,7 +213,7 @@ module Supply
 
       track_body = {
         'track' => track,
-        'userFraction' => 1,
+        'userFraction' => rollout,
         'versionCodes' => [result_upload.data.versionCode]
       }
 

--- a/lib/supply/options.rb
+++ b/lib/supply/options.rb
@@ -13,10 +13,18 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :track,
                                      short_option: "-a",
                                      env_name: "SUPPLY_TRACK",
-                                     description: "The Track to upload the Application to: production, beta, alpha",
+                                     description: "The Track to upload the Application to: production, beta, alpha or rollout",
                                      default_value: 'production',
                                      verify_block: proc do |value|
-                                       available = %w(production beta alpha)
+                                       available = %w(production beta alpha rollout)
+                                       raise "Invalid value '#{value}', must be #{available.join(', ')}".red unless available.include? value
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :rollout,
+                                     short_option: "-r",
+                                     description: "The percentage of the rollout",
+                                     default_value: '1.0',
+                                     verify_block: proc do |value|
+                                       available = %w(0.005 0.01 0.05 0.1 0.2 0.5 1.0)
                                        raise "Invalid value '#{value}', must be #{available.join(', ')}".red unless available.include? value
                                      end),
         FastlaneCore::ConfigItem.new(key: :metadata_path,

--- a/lib/supply/uploader.rb
+++ b/lib/supply/uploader.rb
@@ -69,7 +69,11 @@ module Supply
     def upload_binary
       if Supply.config[:apk]
         Helper.log.info "Preparing apk at path '#{Supply.config[:apk]}' for upload..."
-        client.upload_apk_to_track(Supply.config[:apk], Supply.config[:track])
+        if Supply.config[:track].eql? "rollout"
+          client.upload_apk_to_track_with_rollout(Supply.config[:apk], Supply.config[:track], Supply.config[:rollout])
+        else
+          client.upload_apk_to_track(Supply.config[:apk], Supply.config[:track])
+        end
       else
         Helper.log.info "No apk file found, you can pass the path to your apk using the `apk` option"
       end


### PR DESCRIPTION
I added simple parameter to set percentage of staged rollout.
I think this tool also needs request to update the rollout parameter without uploading apk.
It would be nice to have another request for update recent changes (apklistings) with correlated *.txt file to sync.
Please let me know if there are plans to do this in near future.
Thanks for this awesome open source project!
Happy coding!
