### PR TITLE
Pass passphrase to the client

### DIFF
--- a/lib/supply/client.rb
+++ b/lib/supply/client.rb
@@ -22,9 +22,7 @@ module Supply
     # @param path_to_key: The path to your p12 file
     # @param issuer: Email addresss for oauth
     # @param passphrase: Passphrase for the p12 file
-    def initialize(path_to_key: nil, issuer: nil, passphrase: nil)
-      passphrase ||= "notasecret"
-
+    def initialize(path_to_key: nil, issuer: nil, passphrase: "notasecret")
       key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(path_to_key), passphrase)
 
       begin

--- a/lib/supply/options.rb
+++ b/lib/supply/options.rb
@@ -44,6 +44,11 @@ module Supply
                                      verify_block: proc do |value|
                                        raise "Could not find p12 file at path '#{File.expand_path(value)}'".red unless File.exist?(File.expand_path(value))
                                      end),
+        FastlaneCore::ConfigItem.new(key: :passphrase,
+                                     short_option: "-x",
+                                     env_name: "SUPPLY_KEYSTORE_PW",
+                                     description: "Keystore password",
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:keystore_pw)),
         FastlaneCore::ConfigItem.new(key: :issuer,
                                      short_option: "-i",
                                      env_name: "SUPPLY_ISSUER",

--- a/lib/supply/setup.rb
+++ b/lib/supply/setup.rb
@@ -76,7 +76,8 @@ module Supply
 
     def client
       @client ||= Client.new(path_to_key: Supply.config[:key],
-                                  issuer: Supply.config[:issuer])
+                                  issuer: Supply.config[:issuer],
+                              passphrase: Supply.config[:passphrase])
     end
   end
 end

--- a/lib/supply/uploader.rb
+++ b/lib/supply/uploader.rb
@@ -83,7 +83,8 @@ module Supply
 
     def client
       @client ||= Client.new(path_to_key: Supply.config[:key],
-                                   issuer: Supply.config[:issuer])
+                                  issuer: Supply.config[:issuer],
+                              passphrase: Supply.config[:passphrase])
     end
 
     def metadata_path


### PR DESCRIPTION
If the keychain store is using a password, `supply` doesn't pass it to the client
and hardcodes "notasecret".
In a hope this would allow me to upload to Google Play, this only took me one
step further:

```
~/code/playground/supply/bin/supply \
    --apk build.apk \
    --package_name me.awesome.package.name \
    --key release.p12 \
    --issuer "Evil corporation Inc." \
    --passphrase "1234567789101112"

+--------------+----------------------------------------------------+
|                      Summary for sigh 0.2.2                       |
+--------------+----------------------------------------------------+
| package_name | me.awesome.package.name                            |
| track        | production                                         |
| rollout      | 1.0                                                |
| key          | release.p12                                        |
| passphrase   | asdfasefseff2ik3                                   |
| apk          | build.apk                                          |
+--------------+----------------------------------------------------+

[16:34:50]: Fetching a new access token from Google...
/usr/local/lib/ruby/gems/2.2.0/gems/signet-0.6.1/lib/signet/oauth_2/client.rb:966:in `fetch_access_token': Authorization failed.  Server message: (Signet::AuthorizationError)
{
  "error" : "invalid_grant"
}
        from /usr/local/lib/ruby/gems/2.2.0/gems/signet-0.6.1/lib/signet/oauth_2/client.rb:983:in `fetch_access_token!'
        from /Users/marinusalj/code/playground/supply/lib/supply/client.rb:43:in `initialize'
        from /Users/marinusalj/code/playground/supply/lib/supply/uploader.rb:85:in `new'
        from /Users/marinusalj/code/playground/supply/lib/supply/uploader.rb:85:in `client'
        from /Users/marinusalj/code/playground/supply/lib/supply/uploader.rb:6:in `perform_upload'
        from /Users/marinusalj/code/playground/supply/lib/supply/commands_generator.rb:37:in `block (2 levels) in run'
        from /usr/local/lib/ruby/gems/2.2.0/gems/commander-4.3.5/lib/commander/command.rb:178:in `call'
        from /usr/local/lib/ruby/gems/2.2.0/gems/commander-4.3.5/lib/commander/command.rb:178:in `call'
        from /usr/local/lib/ruby/gems/2.2.0/gems/commander-4.3.5/lib/commander/command.rb:153:in `run'
        from /usr/local/lib/ruby/gems/2.2.0/gems/commander-4.3.5/lib/commander/runner.rb:428:in `run_active_command'
        from /usr/local/lib/ruby/gems/2.2.0/gems/commander-4.3.5/lib/commander/runner.rb:68:in `run!'
        from /usr/local/lib/ruby/gems/2.2.0/gems/commander-4.3.5/lib/commander/delegates.rb:15:in `run!'
        from /Users/marinusalj/code/playground/supply/lib/supply/commands_generator.rb:55:in `run'
        from /Users/marinusalj/code/playground/supply/lib/supply/commands_generator.rb:15:in `start'
        from /Users/marinusalj/code/playground/supply/bin/supply:6:in `<main>'
```
