### PR TITLE
Add missing wearScreenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ And you can supply screenshots by creating directories with the following names,
 - `sevenInchScreenshots/` (7-inch tablets)
 - `tenInchScreenshots/` (10-inch tablets)
 - `tvScreenshots/`
+- `wearScreenshots/`
 
 Note that these will replace the current images and screenshots on the play store listing, not add to them.
 


### PR DESCRIPTION
In supply/lib/supply.rb, wearScreenshots is one of the options.
