### PR TITLE
Update to newer google api client dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,33 @@ Install the gem
 
     sudo gem install supply
 
-## Setup a Google Developers Service Account
+## Setup
+
+Setup consists of setting up your Google Developers Service Account
 
 - Open the [Google Play Console](https://play.google.com/apps/publish/)
 - Select **Settings** tab, followed by the **API access** tab
 - Click the **Create Service Account** button and follow the **Google Developers Console** link in the dialog
 - Click **Add credentials** and select **Service account**
-- Select **P12** as the Key type and click **Create**
-- Make a note of the file name of the P12 file downloaded to your computer, and close the dialog
-- Make a note of the **Email address** under **Service accounts** - this is the issuer which you will need later
+- Select **JSON** as the Key type and click **Create**
+- Make a note of the file name of the JSON file downloaded to your computer, and close the dialog
+- Make a note of the **Email address** under **Service accounts** - this is the user which you will need later
 - Back on the Google Play developer console, click **Done** to close the dialog
 - Click on **Grant Access** for the newly added service account
 - In the **Invite a New User** dialog, paste the service account email address you noted earlier into the **Email address** field
 - Choose **Release Manager** from the **Role** dropdown and click **Send Invitation** to close the dialog
+
+### Migrating Google credential format (from .p12 key file to .json)
+
+In previous versions of supply, credentials to your Play Console were stored as `.p12` files. Since version 0.4.0, supply now supports the recommended `.json` key Service Account credential files. If you wish to upgrade:
+
+- follow the <a href="#setup">Setup</a> procedure once again to make sure you create the appropriate JSON file
+- update your fastlane configuration or your command line invocation to use the appropriate argument if necessary.
+  Note that you don't need to take note nor pass the `issuer` argument anymore.
+
+
+The previous p12 configuration is still currently supported.
+
 
 ## Quick Start
 

--- a/lib/supply/setup.rb
+++ b/lib/supply/setup.rb
@@ -96,8 +96,7 @@ module Supply
     end
 
     def client
-      @client ||= Client.new(path_to_key: Supply.config[:key],
-                                  issuer: Supply.config[:issuer])
+      @client ||= Client.make_from_config
     end
   end
 end

--- a/lib/supply/uploader.rb
+++ b/lib/supply/uploader.rb
@@ -8,7 +8,7 @@ module Supply
       raise "No local metadata found, make sure to run `supply init` to setup supply".red unless metadata_path || Supply.config[:apk]
 
       if metadata_path
-        raise "Could not find folder".red unless File.directory? metadata_path
+        UI.user_error!("Could not find folder #{metadata_path}") unless File.directory? metadata_path
 
         Dir.foreach(metadata_path) do |language|
           next if language.start_with?('.') # e.g. . or .. or hidden folders
@@ -111,8 +111,7 @@ module Supply
     private
 
     def client
-      @client ||= Client.new(path_to_key: Supply.config[:key],
-                                   issuer: Supply.config[:issuer])
+      @client ||= Client.make_from_config
     end
 
     def metadata_path

--- a/supply.gemspec
+++ b/supply.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # External
-  spec.add_dependency 'google-api-client', '~> 0.8.6' # Google API Client to access Play Publishing API
+  spec.add_dependency 'google-api-client', '~> 0.9.1' # Google API Client to access Play Publishing API
 
   # fastlane
-  spec.add_dependency 'fastlane_core', '>= 0.30.0' # all shared code and dependencies
+  spec.add_dependency 'fastlane_core', '>= 0.35.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.10.0'
 
   # Development only


### PR DESCRIPTION
As noted under fastlane/supply#31, there's a new Google API client for supply that might use less requests. Also this client reduces the configuration to one entry, and simplifies the implementation.

I tested:
- download metadata
- upload metadata and images
- apk upload

Worth noting:
- we lost the red coloring on failures. Would prefer solving this in a generic way.

~~I am asking for review new option / documentation. See the various #REVIEW notes in the patch.~~

See also the related patches for fastlane / Appfile integratio: fastlane/fastlane#1212 and fastlane/credentials_manager#29
