### PR TITLE
Enable debugging

### DIFF
--- a/lib/supply/client.rb
+++ b/lib/supply/client.rb
@@ -52,6 +52,10 @@ module Supply
 
       auth_client.fetch_access_token!
 
+      if ENV["DEBUG"]
+        Google::Apis.logger.level = Logger::DEBUG
+      end
+
       Google::Apis::ClientOptions.default.application_name = "fastlane - supply"
       Google::Apis::ClientOptions.default.application_version = Supply::VERSION
 


### PR DESCRIPTION
This allows to display what the client is doing.
We can later on make it more like in spaceship, i.e. log to a file, log something without enabling debugging, etc.

But for a start, it should work. Use

```
DEBUG=.. supply ...
```

to enable
