### PR TITLE
Improve stability while uploading (#59) Timeout to 300s, retries to 5

### DIFF
--- a/lib/supply/client.rb
+++ b/lib/supply/client.rb
@@ -58,6 +58,8 @@ module Supply
 
       Google::Apis::ClientOptions.default.application_name = "fastlane - supply"
       Google::Apis::ClientOptions.default.application_version = Supply::VERSION
+      Google::Apis::RequestOptions.default.timeout_sec = 300
+      Google::Apis::RequestOptions.default.retries = 5
 
       self.android_publisher = Androidpublisher::AndroidPublisherService.new
       self.android_publisher.authorization = auth_client


### PR DESCRIPTION
I used 300 sec as it's the same we use on deliver (note that this timeout doesn't apply to archive uploads in deliver though)
