### PR TITLE
Increase 'open_timeout_sec' to 300sec on Google API request

### DIFF
--- a/lib/supply/client.rb
+++ b/lib/supply/client.rb
@@ -63,6 +63,7 @@ module Supply
       Google::Apis::ClientOptions.default.application_name = "fastlane - supply"
       Google::Apis::ClientOptions.default.application_version = Supply::VERSION
       Google::Apis::RequestOptions.default.timeout_sec = 300
+      Google::Apis::RequestOptions.default.open_timeout_sec = 300
       Google::Apis::RequestOptions.default.retries = 5
 
       self.android_publisher = Androidpublisher::AndroidPublisherService.new


### PR DESCRIPTION
Fixes #76 
